### PR TITLE
Image(image, rectangle) can return nil

### DIFF
--- a/Aseprite-Library.lua
+++ b/Aseprite-Library.lua
@@ -623,7 +623,7 @@ Image = {}
     ---@overload fun(spec: ImageSpec): Image
     ---@overload fun(sprite: Sprite): Image
     ---@overload fun(otherImage: Image): Image
-    ---@overload fun(otherImage: Image, rectangle: Rectangle): Image
+    ---@overload fun(otherImage: Image, rectangle: Rectangle): Image | nil
     ---@overload fun(table: { fromFile: string }): Image
     function Image() end
 


### PR DESCRIPTION
`Image(image, rectangle)` is not type `Image`. It may return `nil` so it is type `Image | nil`

`---@overload fun(otherImage: Image, rectangle: Rectangle): Image`
into
`---@overload fun(otherImage: Image, rectangle: Rectangle): Image | nil`

https://github.com/aseprite/aseprite/issues/4514